### PR TITLE
Axiell events

### DIFF
--- a/router.php
+++ b/router.php
@@ -21,5 +21,6 @@ require_once 'vendor/autoload.php';
     "authscope:",
     "typesense_apikey:",
     "typesense_host:",
-    "typesense_port:"
+    "typesense_port:",
+    "externalbaseurl:",
 ]));

--- a/router.php
+++ b/router.php
@@ -23,4 +23,5 @@ require_once 'vendor/autoload.php';
     "typesense_host:",
     "typesense_port:",
     "externalbaseurl:",
+    "excludetags:",
 ]));

--- a/router.php
+++ b/router.php
@@ -24,4 +24,5 @@ require_once 'vendor/autoload.php';
     "typesense_port:",
     "externalbaseurl:",
     "excludetags:",
+    "includetags:",
 ]));

--- a/scripts/axiell-events/run-local.sh
+++ b/scripts/axiell-events/run-local.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+if [ -z ${AXIELL_EVENTS_URL} ]; then
+    echo "Missing env variable AXIELL_EVENTS_URL"; exit 1
+fi
+which php >/dev/null
+if [ $? -ne 0 ]; then
+    echo "PHP command missing or not in path"; exit 1
+fi
+cd ${SCRIPT_DIR}
+
+# --source_json_path "$.hits[*].event" \
+
+# Retrieve and transform Axiell events data
+php ../../router.php \
+    --source ${AXIELL_EVENTS_URL} \
+    --transform axiell_events \
+    --outputformat json \
+    --idprefix AXIELL \
+
+if [ $? -ne 0 ]; then
+    echo "FAILED to transform request"
+fi

--- a/scripts/axiell-events/run-local.sh
+++ b/scripts/axiell-events/run-local.sh
@@ -10,14 +10,12 @@ if [ $? -ne 0 ]; then
 fi
 cd ${SCRIPT_DIR}
 
-# --source_json_path "$.hits[*].event" \
-
 # Retrieve and transform Axiell events data
 php ../../router.php \
     --source ${AXIELL_EVENTS_URL} \
     --transform axiell_events \
     --outputformat json \
-    --idprefix AXIELL \
+    --idprefix ax- \
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run-local.sh
+++ b/scripts/hbg-bibliotek-events/run-local.sh
@@ -17,7 +17,8 @@ php ../../router.php \
     --outputformat json \
     --idprefix ax- \
     --externalbaseurl https://bibliotekfh.se/evenemang#/events/ \
-    --excludetags "rådgivning,inställt"
+    --excludetags "rådgivning,inställt" \
+    --includetags ""
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run-local.sh
+++ b/scripts/hbg-bibliotek-events/run-local.sh
@@ -16,7 +16,7 @@ php ../../router.php \
     --transform axiell_events \
     --outputformat json \
     --idprefix ax- \
-    --externalbaseurl https://bibliotekfh.se \
+    --externalbaseurl https://bibliotekfh.se/evenemang#/events/ \
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run-local.sh
+++ b/scripts/hbg-bibliotek-events/run-local.sh
@@ -17,6 +17,7 @@ php ../../router.php \
     --outputformat json \
     --idprefix ax- \
     --externalbaseurl https://bibliotekfh.se/evenemang#/events/ \
+    --excludetags "rådgivning,inställt"
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run-local.sh
+++ b/scripts/hbg-bibliotek-events/run-local.sh
@@ -16,6 +16,7 @@ php ../../router.php \
     --transform axiell_events \
     --outputformat json \
     --idprefix ax- \
+    --externalbaseurl https://bibliotekfh.se \
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run.sh
+++ b/scripts/hbg-bibliotek-events/run.sh
@@ -21,7 +21,7 @@ cd ${SCRIPT_DIR}
         --outputformat jsonl \
         --output ${TMPFILE} \
         --idprefix ax- \
-        --externalbaseurl https://bibliotekfh.se \
+        --externalbaseurl https://bibliotekfh.se/evenemang#/events/ \
 
     if [ $? -ne 0 ]; then
         echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run.sh
+++ b/scripts/hbg-bibliotek-events/run.sh
@@ -22,6 +22,7 @@ cd ${SCRIPT_DIR}
         --output ${TMPFILE} \
         --idprefix ax- \
         --externalbaseurl https://bibliotekfh.se/evenemang#/events/ \
+        --excludetags "rådgivning"
 
     if [ $? -ne 0 ]; then
         echo "FAILED to transform request"

--- a/scripts/hbg-bibliotek-events/run.sh
+++ b/scripts/hbg-bibliotek-events/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+TYPESENSE_PATH=${TYPESENSE_BASE_PATH}/collections/test-events/documents
+TMPFILE=$(mktemp)
+if [ -z ${AXIELL_EVENTS_URL} ]; then
+    echo "Missing env variable AXIELL_EVENTS_URL"; exit 1
+fi
+which php >/dev/null
+if [ $? -ne 0 ]; then
+    echo "PHP command missing or not in path"; exit 1
+fi
+cd ${SCRIPT_DIR}
+
+(
+    flock -n 9 || exit 1
+
+    # Retrieve and transform Axiell events data
+    php ../../router.php \
+        --source ${AXIELL_EVENTS_URL} \
+        --transform axiell_events \
+        --outputformat jsonl \
+        --output ${TMPFILE} \
+        --idprefix ax- \
+        --externalbaseurl https://bibliotekfh.se \
+
+    if [ $? -ne 0 ]; then
+        echo "FAILED to transform request"
+    else
+        # Clear collection
+        echo "Deleting documents"
+        curl -X DELETE \
+            -H "x-typesense-api-key: ${TYPESENSE_APIKEY}" \
+            -H "Content-Type: application/json" \
+            "${TYPESENSE_BASE_PATH}/collections/test-events/documents?filter_by=x-created-by:=municipio%3A%2F%2Fschema.org-transformer%2Faxiell-events"
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to delete documents"
+        fi
+
+        # POST result to typesense
+        echo "Creating documents"
+        curl ${TYPESENSE_PATH}/import?action=create -X POST --data-binary @${TMPFILE} -H "Content-Type: text/plain" -H "x-typesense-api-key: ${TYPESENSE_APIKEY}"
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to upload document"
+        fi
+
+        # Clear typesense cache
+        echo "Clearing Typesense cache"
+        curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_APIKEY}" -X POST ${TYPESENSE_BASE_PATH}/operations/cache/clear
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to clear Typesense cache"
+        else
+            # Call monitoring url if set
+            if [ -n "$AXIELL_EVENTS_MONITOR_URL" ]; then curl -s "$AXIELL_EVENTS_MONITOR_URL" >/dev/null; fi
+        fi
+
+    fi
+    # Remove temp file
+    rm -f ${TMPFILE}
+) 9>/tmp/hbg-bibliotek-events.lock

--- a/src/App.php
+++ b/src/App.php
@@ -43,6 +43,7 @@ class App
             "typesense_port"   => "",
             "externalbaseurl"  => "",
             "excludetags"      => "",
+            "includetags"      => "",
         ], $options);
 
         if (empty($cmd->source)) {
@@ -71,6 +72,7 @@ class App
                 --idprefix                      prefix to avoid collision between items from multiple sources
                 --externalbaseurl               Base URL to use for generating external URLs (applicable for some transforms, e.g. events)
                 --excludetags                   Comma separated list of tags to exclude (applicable for some transforms, e.g. events)
+                --includetags                   Comma separated list of tags to include (applicable for some transforms, e.g. events)
                 OAuth authentication parameters (Applicable for source only)
                  --authpath <url>               URL of token service
                  --authclientid <string>        Client id 

--- a/src/App.php
+++ b/src/App.php
@@ -31,7 +31,7 @@ class App
             "output"           => "",
             "outputheaders"    => "Content-Type: application/json",
             "outputformat"     => "json",
-            "transform"        => "jobposting",
+            "transform"        => "",
             "idprefix"         => "",
             "authpath"         => "",
             "authclientid"     => "",
@@ -195,6 +195,12 @@ class App
                 break;
             case 'tix_events':
                 $result = $services->getTixService()->execute(
+                    $cmd->source,
+                    $cmd->output
+                );
+                break;
+            case 'axiell_events':
+                $result = $services->getAxiellEventsService()->execute(
                     $cmd->source,
                     $cmd->output
                 );

--- a/src/App.php
+++ b/src/App.php
@@ -41,6 +41,7 @@ class App
             "typesense_apikey" => "",
             "typesense_host"   => "",
             "typesense_port"   => "",
+            "externalbaseurl"  => "",
         ], $options);
 
         if (empty($cmd->source)) {
@@ -146,7 +147,7 @@ class App
             new JSONConverter();
 
             // Wire services
-        $services = new RuntimeServices($reader, $writer, $converter, $cmd->idprefix, $typesenseClient);
+        $services = new RuntimeServices($cmd, $reader, $writer, $converter, $cmd->idprefix, $typesenseClient);
 
         // Execute
         $result = false;

--- a/src/App.php
+++ b/src/App.php
@@ -42,6 +42,7 @@ class App
             "typesense_host"   => "",
             "typesense_port"   => "",
             "externalbaseurl"  => "",
+            "excludetags"      => "",
         ], $options);
 
         if (empty($cmd->source)) {
@@ -68,7 +69,8 @@ class App
                                                 - wp_exhibition_event
                                                 - elementary_school
                 --idprefix                      prefix to avoid collision between items from multiple sources
-                 
+                --externalbaseurl               Base URL to use for generating external URLs (applicable for some transforms, e.g. events)
+                --excludetags                   Comma separated list of tags to exclude (applicable for some transforms, e.g. events)
                 OAuth authentication parameters (Applicable for source only)
                  --authpath <url>               URL of token service
                  --authclientid <string>        Client id 

--- a/src/IO/FileReader.php
+++ b/src/IO/FileReader.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace SchemaTransformer\IO;
 
+use SchemaTransformer\Interfaces\AbstractDataPreprocessor;
 use SchemaTransformer\Interfaces\AbstractDataReader;
 
 class FileReader implements AbstractDataReader
 {
-    public function read(string $path): array|false
+    public function read(string $path, AbstractDataPreprocessor $preprocessor): array|false
     {
         $file = file_get_contents($path);
 
         if (false === $file) {
             return false;
         }
-        return json_decode($file, true);
+        return $preprocessor->preprocessData(json_decode($file, true));
     }
 }

--- a/src/IO/HttpReader.php
+++ b/src/IO/HttpReader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SchemaTransformer\IO;
 
+use SchemaTransformer\Interfaces\AbstractDataPreprocessor;
 use SchemaTransformer\Interfaces\AbstractDataReader;
 use SchemaTransformer\Interfaces\AbstractLogger;
 use SchemaTransformer\Interfaces\AbstractPaginator;
@@ -22,7 +23,7 @@ class HttpReader implements AbstractDataReader
         $this->headers   = $headers;
         $this->paginator = $paginator;
     }
-    public function read(string $path): array|false
+    public function read(string $path, AbstractDataPreprocessor $preprocessor): array|false
     {
         $result = [];
 
@@ -32,9 +33,8 @@ class HttpReader implements AbstractDataReader
 
             list($response, $headers) = $this->curl($next);
             // Extend list
-            $result = [...$result, ...$response];
-            // Get next page
-            $next = $this->paginator->getNext($next, $headers);
+            $result = [...$result, ...$preprocessor->preprocessData($response)];
+            $next   = $this->paginator->getNext($next, $headers);
         };
 
         $this->logger->log("✅ Read " . count($result) . " items from source");

--- a/src/Interfaces/AbstractDataPreprocessor.php
+++ b/src/Interfaces/AbstractDataPreprocessor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Interfaces;
+
+interface AbstractDataPreprocessor
+{
+    public function preprocessData(array $data): array;
+}

--- a/src/Interfaces/AbstractDataReader.php
+++ b/src/Interfaces/AbstractDataReader.php
@@ -6,5 +6,5 @@ namespace SchemaTransformer\Interfaces;
 
 interface AbstractDataReader
 {
-    public function read(string $path): array|false;
+    public function read(string $path, AbstractDataPreprocessor $preprocessor): array|false;
 }

--- a/src/Interfaces/AbstractDataTransform.php
+++ b/src/Interfaces/AbstractDataTransform.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SchemaTransformer\Interfaces;
 
-interface AbstractDataTransform
+interface AbstractDataTransform extends AbstractDataPreprocessor
 {
     public function transform(array $data): array;
 }

--- a/src/Paginators/GetParamPaginator.php
+++ b/src/Paginators/GetParamPaginator.php
@@ -6,6 +6,7 @@ namespace SchemaTransformer\Paginators;
 
 use SchemaTransformer\Interfaces\AbstractDataReader;
 use SchemaTransformer\Interfaces\AbstractPaginator;
+use SchemaTransformer\Transforms\NullDataPreprocessor;
 
 final class GetParamPaginator implements AbstractPaginator
 {
@@ -19,7 +20,7 @@ final class GetParamPaginator implements AbstractPaginator
 
         $nextUrl = $this->applyPageParameter($previous, $nextPageNumber);
 
-        if ($this->reader->read($nextUrl) !== false) {
+        if ($this->reader->read($nextUrl, new NullDataPreprocessor()) !== false) {
             return $nextUrl;
         }
 

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -19,6 +19,7 @@ use SchemaTransformer\Transforms\School\PreSchool\PreSchoolTransform;
 use SchemaTransformer\Transforms\Event\TixEvents\TixEventTransform;
 use SchemaTransformer\Transforms\Event\WPLegacyEvents\WPLegacyEventTransform;
 use SchemaTransformer\Transforms\Event\WPHeadLessEvents\WPHeadlessEventTransform;
+use SchemaTransformer\Transforms\Event\AxiellEvents\AxiellEventTransform;
 
 class RuntimeServices
 {
@@ -30,6 +31,7 @@ class RuntimeServices
     private AbstractService $elementarySchoolService;
     private AbstractService $preSchoolService;
     private AbstractService $tixEventService;
+    private AbstractService $axiellEventsService;
 
     public function __construct(
         AbstractDataReader $reader,
@@ -65,6 +67,7 @@ class RuntimeServices
         $this->elementarySchoolService  = new Service($reader, $writer, new ElementarySchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->preSchoolService         = new Service($reader, $writer, new PreSchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->tixEventService          = new Service($reader, $writer, new TixEventTransform($idprefix), $converter);
+        $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform($idprefix), $converter);
     }
 
     public function getJobPostingService(): AbstractService
@@ -99,5 +102,10 @@ class RuntimeServices
     public function getTixService(): AbstractService
     {
         return $this->tixEventService;
+    }
+
+    public function getAxiellEventsService(): AbstractService
+    {
+        return $this->axiellEventsService;
     }
 }

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -68,7 +68,11 @@ class RuntimeServices
         $this->elementarySchoolService  = new Service($reader, $writer, new ElementarySchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->preSchoolService         = new Service($reader, $writer, new PreSchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->tixEventService          = new Service($reader, $writer, new TixEventTransform($idprefix), $converter);
-        $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform($idprefix, $commandlineOptions->externalbaseurl ?? ''), $converter);
+        $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform(
+            $idprefix,
+            $commandlineOptions->externalbaseurl ?? '',
+            explode(',', $commandlineOptions->excludetags ?? '')
+        ), $converter);
     }
 
     public function getJobPostingService(): AbstractService

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -34,6 +34,7 @@ class RuntimeServices
     private AbstractService $axiellEventsService;
 
     public function __construct(
+        object $commandlineOptions,
         AbstractDataReader $reader,
         AbstractDataWriter $writer,
         AbstractDataConverter $converter,
@@ -67,7 +68,7 @@ class RuntimeServices
         $this->elementarySchoolService  = new Service($reader, $writer, new ElementarySchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->preSchoolService         = new Service($reader, $writer, new PreSchoolTransform($idprefix, $this->typesenseClient), $converter);
         $this->tixEventService          = new Service($reader, $writer, new TixEventTransform($idprefix), $converter);
-        $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform($idprefix), $converter);
+        $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform($idprefix, $commandlineOptions->externalbaseurl ?? ''), $converter);
     }
 
     public function getJobPostingService(): AbstractService

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -73,6 +73,9 @@ class RuntimeServices
             $commandlineOptions->externalbaseurl ?? '',
             array_values(array_filter(
                 preg_split("/\s*,\s*/", $commandlineOptions->excludetags ?? '')
+            )),
+            array_values(array_filter(
+                preg_split("/\s*,\s*/", $commandlineOptions->includetags ?? '')
             ))
         ), $converter);
     }

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -71,7 +71,9 @@ class RuntimeServices
         $this->axiellEventsService      = new Service($reader, $writer, new AxiellEventTransform(
             $idprefix,
             $commandlineOptions->externalbaseurl ?? '',
-            explode(',', $commandlineOptions->excludetags ?? '')
+            array_values(array_filter(
+                preg_split("/\s*,\s*/", $commandlineOptions->excludetags ?? '')
+            ))
         ), $converter);
     }
 

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -31,7 +31,7 @@ class Service implements AbstractService
     }
     public function execute(string $source, string $destination): bool
     {
-        $data = $this->reader->read($source);
+        $data = $this->reader->read($source, $this->transform);
         if (false === $data) {
             return false;
         }

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -32,10 +32,11 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
     private array $excludeTags = ['rådgivning'];
     private string $externalBaseUrl;
 
-    public function __construct(string $idprefix, string $externalBaseUrl)
+    public function __construct(string $idprefix, string $externalBaseUrl, array $excludeTags = [])
     {
         parent::__construct($idprefix);
         $this->externalBaseUrl = $externalBaseUrl;
+        $this->excludeTags     = $excludeTags;
     }
 
     public function preprocessData(array $data): array
@@ -52,7 +53,7 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
             (count(
                 array_intersect(
                     array_map('strtolower', $item['tags'] ?? []),
-                    $this->excludeTags
+                    array_map('strtolower', $this->excludeTags)
                 )
             ) === 0) && ($item['endDate'] ?? '') >= $retentionDate
         );

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SchemaTransformer\Transforms\Event\AxiellEvents;
 
+use DateTime;
 use Municipio\Schema\Schema;
 use SchemaTransformer\Transforms\TransformBase;
 use SchemaTransformer\Interfaces\AbstractDataTransform;
@@ -38,17 +39,21 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
 
     public function preprocessData(array $data): array
     {
+        // NOTE: HARDCODED RETENTION DATE FOR EVENTS, SHOULD BE REPLACED WITH A CONFIGURABLE OPTION
+        $retentionDate = (new DateTime())->sub(new \DateInterval('P1M'))->format('Y-m-d'); // Subtract 1 month from the current date
+
         // Implement any necessary preprocessing steps here
         return array_filter(
             // project $.hits[*].event
             array_map(fn($item) => $item['event'] ?? [], $data['hits'] ?? []),
-            // filter out events that have any of the exclude tags
-            fn($item) => count(
+            // filter out events that have any of the exclude tags or have an end date before the retention date
+            fn($item) =>
+            (count(
                 array_intersect(
                     array_map('strtolower', $item['tags'] ?? []),
                     $this->excludeTags
                 )
-            ) === 0
+            ) === 0) && ($item['endDate'] ?? '') >= $retentionDate
         );
     }
 

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -73,7 +73,7 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
             new MapLocation(),
             new MapImage(),
             new MapEventSchedule(),
-            new MapOffers(), // Do not include products in offers
+            new MapOffers(),
             new MapEventStatus(),
             new MapKeywords(),
             new MapPhysicalAccessibilityFeatures(),
@@ -81,15 +81,14 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
             new MapUrl($this->externalBaseUrl),
             new MapXCreatedBy()
         ];
-        $result  = array_map(function ($item) use ($mappers) {
-            return array_reduce(
+        $result  = array_map(
+            fn ($item) => array_reduce(
                 $mappers,
-                function ($event, $mapper) use ($item) {
-                    return $mapper->map($event, $item);
-                },
+                fn ($event, $mapper) => $mapper->map($event, $item),
                 Schema::event()
-            )->toArray();
-        }, $data);
+            )->toArray(),
+            $data
+        );
         return $result;
     }
 }

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents;
+
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\TransformBase;
+use SchemaTransformer\Interfaces\AbstractDataTransform;
+
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapDescription;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEndDate;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventAttendanceMode;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventSchedule;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapIsAccessibleForFree;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapName;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapStartDate;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapIdentifier;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapImage;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapLocation;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapOffers;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapOrganizer;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventStatus;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapKeywords;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapPhysicalAccessibilityFeatures;
+// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapXCreatedBy;
+
+class AxiellEventTransform extends TransformBase implements AbstractDataTransform
+{
+    public function __construct(string $idprefix)
+    {
+        parent::__construct($idprefix);
+    }
+
+    public function preprocessData(array $data): array
+    {
+        // Implement any necessary preprocessing steps here
+        return $data['hits'] ?? [];
+    }
+
+    public function transform(array $data): array
+    {
+        $mappers = [
+            // new MapIdentifier($this),
+            // new MapName(),
+            // new MapDescription(),
+            // new MapIsAccessibleForFree(),
+            // new MapEventAttendanceMode(),
+            // new MapStartDate(),
+            // new MapEndDate(),
+            // new MapOrganizer(),
+            // new MapLocation(),
+            // new MapImage(),
+            // new MapEventSchedule($this),
+            // new MapOffers(false), // Do not include products in offers
+            // new MapEventStatus(),
+            // new MapKeywords(),
+            // new MapPhysicalAccessibilityFeatures(),
+            // new MapXCreatedBy()
+        ];
+        $result = array_map(function ($item) use ($mappers) {
+            return array_reduce(
+                $mappers,
+                function ($event, $mapper) use ($item) {
+                    return $mapper->map($event, $item);
+                },
+                Schema::event()
+            )->toArray();
+        }, $data);
+        return $result;
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -10,34 +10,35 @@ use SchemaTransformer\Interfaces\AbstractDataTransform;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapDescription;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEndDate;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventAttendanceMode;
-// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventSchedule;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventSchedule;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIsAccessibleForFree;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapName;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapStartDate;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIdentifier;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapImage;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapLocation;
-// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOffers;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOffers;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOrganizer;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventStatus;
-// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapKeywords;
-// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPhysicalAccessibilityFeatures;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapKeywords;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPhysicalAccessibilityFeatures;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapUrl;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapXCreatedBy;
 
 class AxiellEventTransform extends TransformBase implements AbstractDataTransform
 {
     private array $excludeTags = ['rådgivning'];
+    private string $externalBaseUrl;
 
-    public function __construct(string $idprefix)
+    public function __construct(string $idprefix, string $externalBaseUrl)
     {
         parent::__construct($idprefix);
+        $this->externalBaseUrl = $externalBaseUrl;
     }
 
     public function preprocessData(array $data): array
     {
         // Implement any necessary preprocessing steps here
-
-
         return array_filter(
             // project $.hits[*].event
             array_map(fn($item) => $item['event'] ?? [], $data['hits'] ?? []),
@@ -64,11 +65,12 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
             new MapOrganizer(),
             new MapLocation(),
             new MapImage(),
-            // new MapEventSchedule($this),
-            // new MapOffers(false), // Do not include products in offers
+            new MapEventSchedule(),
+            new MapOffers(), // Do not include products in offers
             new MapEventStatus(),
-            // new MapKeywords(),
-            // new MapPhysicalAccessibilityFeatures(),
+            new MapKeywords(),
+            new MapPhysicalAccessibilityFeatures(),
+            new MapUrl($this->externalBaseUrl),
             new MapXCreatedBy()
         ];
         $result  = array_map(function ($item) use ($mappers) {

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -7,26 +7,27 @@ namespace SchemaTransformer\Transforms\Event\AxiellEvents;
 use Municipio\Schema\Schema;
 use SchemaTransformer\Transforms\TransformBase;
 use SchemaTransformer\Interfaces\AbstractDataTransform;
-
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapDescription;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEndDate;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventAttendanceMode;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventSchedule;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapIsAccessibleForFree;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapName;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapStartDate;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapIdentifier;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapImage;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapLocation;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapOffers;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapOrganizer;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapEventStatus;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapKeywords;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapPhysicalAccessibilityFeatures;
-// use SchemaTransformer\Transforms\Event\TixEvents\Mappers\MapXCreatedBy;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapDescription;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEndDate;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventAttendanceMode;
+// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventSchedule;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIsAccessibleForFree;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapName;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapStartDate;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIdentifier;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapImage;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapLocation;
+// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOffers;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOrganizer;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventStatus;
+// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapKeywords;
+// use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPhysicalAccessibilityFeatures;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapXCreatedBy;
 
 class AxiellEventTransform extends TransformBase implements AbstractDataTransform
 {
+    private array $excludeTags = ['rådgivning'];
+
     public function __construct(string $idprefix)
     {
         parent::__construct($idprefix);
@@ -35,30 +36,42 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
     public function preprocessData(array $data): array
     {
         // Implement any necessary preprocessing steps here
-        return $data['hits'] ?? [];
+
+
+        return array_filter(
+            // project $.hits[*].event
+            array_map(fn($item) => $item['event'] ?? [], $data['hits'] ?? []),
+            // filter out events that have any of the exclude tags
+            fn($item) => count(
+                array_intersect(
+                    array_map('strtolower', $item['tags'] ?? []),
+                    $this->excludeTags
+                )
+            ) === 0
+        );
     }
 
     public function transform(array $data): array
     {
         $mappers = [
-            // new MapIdentifier($this),
-            // new MapName(),
-            // new MapDescription(),
-            // new MapIsAccessibleForFree(),
-            // new MapEventAttendanceMode(),
-            // new MapStartDate(),
-            // new MapEndDate(),
-            // new MapOrganizer(),
-            // new MapLocation(),
-            // new MapImage(),
+            new MapIdentifier($this),
+            new MapName(),
+            new MapDescription(),
+            new MapIsAccessibleForFree(),
+            new MapEventAttendanceMode(),
+            new MapStartDate(),
+            new MapEndDate(),
+            new MapOrganizer(),
+            new MapLocation(),
+            new MapImage(),
             // new MapEventSchedule($this),
             // new MapOffers(false), // Do not include products in offers
-            // new MapEventStatus(),
+            new MapEventStatus(),
             // new MapKeywords(),
             // new MapPhysicalAccessibilityFeatures(),
-            // new MapXCreatedBy()
+            new MapXCreatedBy()
         ];
-        $result = array_map(function ($item) use ($mappers) {
+        $result  = array_map(function ($item) use ($mappers) {
             return array_reduce(
                 $mappers,
                 function ($event, $mapper) use ($item) {

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -31,12 +31,14 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
 {
     private array $excludeTags = ['rådgivning'];
     private string $externalBaseUrl;
+    private array $includeTags = [];
 
-    public function __construct(string $idprefix, string $externalBaseUrl, array $excludeTags = [])
+    public function __construct(string $idprefix, string $externalBaseUrl, array $excludeTags = [], array $includeTags = [])
     {
         parent::__construct($idprefix);
         $this->externalBaseUrl = $externalBaseUrl;
-        $this->excludeTags     = $excludeTags;
+        $this->excludeTags     = array_map('strtolower', $excludeTags);
+        $this->includeTags     = array_map('strtolower', $includeTags);
     }
 
     public function preprocessData(array $data): array
@@ -44,18 +46,33 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
         // NOTE: HARDCODED RETENTION DATE FOR EVENTS, SHOULD BE REPLACED WITH A CONFIGURABLE OPTION
         $retentionDate = (new DateTime())->sub(new \DateInterval('P1M'))->format('Y-m-d'); // Subtract 1 month from the current date
 
-        // Implement any necessary preprocessing steps here
-        return array_filter(
-            // project $.hits[*].event
-            array_map(fn($item) => $item['event'] ?? [], $data['hits'] ?? []),
-            // filter out events that have any of the exclude tags or have an end date before the retention date
-            fn($item) =>
-            (count(
+        $filters = [
+            // filter out events that have an end date before the retention date
+            fn($item) => ($item['endDate'] ?? '') >= $retentionDate,
+            // filter out events that have any of the exclude tags
+            fn($item) => count(
                 array_intersect(
                     array_map('strtolower', $item['tags'] ?? []),
-                    array_map('strtolower', $this->excludeTags)
+                    $this->excludeTags
                 )
-            ) === 0) && ($item['endDate'] ?? '') >= $retentionDate
+            ) === 0,
+            // if includeTags is not empty, filter in only events that have at least one of the include tags
+            fn($item) =>
+                empty($this->includeTags)
+                || count(
+                    array_intersect(
+                        array_map('strtolower', $item['tags'] ?? []),
+                        $this->includeTags
+                    )
+                ) > 0
+        ];
+
+        return array_reduce(
+            $filters,
+            // apply filter to events
+            fn($data, $filter) => array_filter($data, $filter),
+            // project $.hits[*].event
+            array_map(fn($item) => $item['event'] ?? [], $data['hits'] ?? [])
         );
     }
 

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransform.php
@@ -22,6 +22,7 @@ use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOffers;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOrganizer;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventStatus;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapKeywords;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPotentialAction;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPhysicalAccessibilityFeatures;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapUrl;
 use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapXCreatedBy;
@@ -75,6 +76,7 @@ class AxiellEventTransform extends TransformBase implements AbstractDataTransfor
             new MapEventStatus(),
             new MapKeywords(),
             new MapPhysicalAccessibilityFeatures(),
+            new MapPotentialAction(),
             new MapUrl($this->externalBaseUrl),
             new MapXCreatedBy()
         ];

--- a/src/Transforms/Event/AxiellEvents/AxiellEventTransformTest.php
+++ b/src/Transforms/Event/AxiellEvents/AxiellEventTransformTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\AxiellEventTransform;
+
+#[CoversClass(AxiellEventTransform::class)]
+final class AxiellEventTransformTest extends TestCase
+{
+    private function prepareJsonForTransform($json)
+    {
+        return json_decode($json, true);
+    }
+
+    #[TestDox('it doesn\'t break when a lot is missing')]
+    public function testAlmostNoSourceData()
+    {
+        $source        = $this->prepareJsonForTransform('{
+            "id": 123
+            }');
+        $expectedEvent = Schema::event()
+            ->identifier("ax-123")
+            ->name(null)
+            ->description([])
+            ->isAccessibleForFree(true)
+            ->eventAttendanceMode(Schema::eventAttendanceModeEnumeration()::OfflineEventAttendanceMode)
+            ->startDate(null)
+            ->endDate(null)
+            ->organizer([])
+            ->location([])
+            ->image([])
+            ->eventSchedule([])
+            ->offers([])
+            ->eventStatus(Schema::eventStatusType()::EventScheduled)
+            ->keywords([])
+            ->physicalAccessibilityFeatures([])
+            ->typicalAgeRange(null)
+            ->url('https://example.com/event/123')
+            ->potentialAction([])
+            ->setProperty('x-created-by', 'municipio://schema.org-transformer/axiell-events');
+
+        $actualEvent = (new AxiellEventTransform('ax-', 'https://example.com/event/'))->transform(
+            [$source]
+        )[0];
+
+        $this->assertEquals(
+            $expectedEvent->toArray(),
+            $actualEvent
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/AbstractAxiellEventsDataMapper.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/AbstractAxiellEventsDataMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+use SchemaTransformer\Transforms\TransformBase;
+
+abstract class AbstractAxiellEventsDataMapper implements AxiellEventsDataMapperInterface
+{
+    public function __construct(private ?TransformBase $transform = null)
+    {
+    }
+
+    abstract public function map(Event $event, array $data): Event;
+
+    protected function formatId(string | int $value): string
+    {
+        return $this->transform->formatId($value);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/AxiellEventsDataMapperInterface.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/AxiellEventsDataMapperInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+interface AxiellEventsDataMapperInterface
+{
+    public function map(Event $event, array $data): Event;
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapDescription extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->description($data['description'] ?? null);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
@@ -11,6 +11,12 @@ class MapDescription extends AbstractAxiellEventsDataMapper
     public function map(Event $event, array $data): Event
     {
         return $event
-            ->description($data['description'] ?? null);
+            ->description(
+                array_values(
+                    array_filter(
+                        [$data['description'] ?? null]
+                    )
+                )
+            );
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapDescription.php
@@ -8,11 +8,6 @@ use Municipio\Schema\Event;
 
 class MapDescription extends AbstractAxiellEventsDataMapper
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function map(Event $event, array $data): Event
     {
         return $event

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapEndDate.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapEndDate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapEndDate extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->endDate($data['endDate'] ?? null);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapEventAttendanceMode.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapEventAttendanceMode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapEventAttendanceMode extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event->eventAttendanceMode('https://schema.org/OfflineEventAttendanceMode');
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapEventSchedule.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapEventSchedule.php
@@ -11,12 +11,18 @@ class MapEventSchedule extends AbstractAxiellEventsDataMapper
 {
     public function map(Event $event, array $data): Event
     {
-        return $event->eventSchedule([
-            Schema::schedule()
-                ->startDate($data['startDate'] ?? null)
-                ->endDate($data['endDate'] ?? null)
-                ->description(null)
-                ->url(null)
-        ]);
+        return $event->eventSchedule(
+            array_values(
+                array_filter([
+                    empty($data['startDate'])
+                        ? null
+                        : Schema::schedule()
+                            ->startDate($data['startDate'] ?? null)
+                            ->endDate($data['endDate'] ?? null)
+                            ->description(null)
+                            ->url(null)
+                ])
+            )
+        );
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapEventSchedule.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapEventSchedule.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapEventSchedule extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        return $event->eventSchedule([
+            Schema::schedule()
+                ->startDate($data['startDate'] ?? null)
+                ->endDate($data['endDate'] ?? null)
+                ->description(null)
+                ->url(null)
+        ]);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapEventStatus.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapEventStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapEventStatus extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        return $event->eventStatus(Schema::eventStatusType()::EventScheduled);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapIdentifier.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapIdentifier.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+use SchemaTransformer\Transforms\TransformBase;
+
+class MapIdentifier extends AbstractAxiellEventsDataMapper
+{
+    public function __construct(private TransformBase $transform)
+    {
+        parent::__construct($transform);
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->identifier($this->formatId($data['id'] ?? null));
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapImage.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapImage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapImage extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->image(
+                array_filter(
+                    array_values(
+                        array_map(
+                            fn($img) => empty($img['imageUrl'])
+                                ? null
+                                : Schema::imageObject()
+                                    ->url($img['imageUrl'] ?? null)
+                                    ->caption($img['imageCaption'] ?? null)
+                                    ->description($img['imageCaption'] ?? null),
+                            $data['images'] ?? []
+                        )
+                    )
+                )
+            );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapImage.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapImage.php
@@ -9,11 +9,6 @@ use Municipio\Schema\Event;
 
 class MapImage extends AbstractAxiellEventsDataMapper
 {
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function map(Event $event, array $data): Event
     {
         return $event

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapIsAccessibleForFree.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapIsAccessibleForFree.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapIsAccessibleForFree extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->isAccessibleForFree(true);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapKeywords.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapKeywords.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapKeywords extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        return $event->keywords(
+            array_values(
+                array_map(
+                    fn($tag) =>
+                    Schema::definedTerm()
+                        ->name($tag)
+                        ->inDefinedTermSet(Schema::definedTermSet()->name('tags')),
+                    $data['tags'] ?? []
+                )
+            )
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapLocation.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapLocation.php
@@ -12,10 +12,12 @@ class MapLocation extends AbstractAxiellEventsDataMapper
     public function map(Event $event, array $data): Event
     {
         $location = $data['location']['value'] ?? null;
-        return empty($location) ? $event : $event->location([
-                Schema::place()
-                    ->name($location)
-                    ->description($data['room']['value'] ?? null)
-            ]);
+        return $event->location(
+            array_values(
+                array_filter(
+                    [empty($location) ? null : Schema::place()->name($location)->description($data['room']['value'] ?? null)]
+                )
+            )
+        );
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapLocation.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapLocation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapLocation extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        $location = $data['location']['value'] ?? null;
+        return empty($location) ? $event : $event->location([
+                Schema::place()
+                    ->name($location)
+                    ->description($data['room']['value'] ?? null)
+            ]);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapName.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapName.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapName extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->name($data['title'] ?? null);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapOffers.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapOffers.php
@@ -6,11 +6,10 @@ namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
 
 use Municipio\Schema\Event;
 
-class MapName extends AbstractAxiellEventsDataMapper
+class MapOffers extends AbstractAxiellEventsDataMapper
 {
     public function map(Event $event, array $data): Event
     {
-        return $event
-            ->name($data['title'] ?? null);
+        return $event->offers([]);
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapOrganizer.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapOrganizer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+
+class MapOrganizer extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        $location = $data['location']['value'] ?? null;
+        return empty($location) ? $event : $event
+            ->organizer([
+                Schema::organization()
+                    ->name($location)
+            ]);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapOrganizer.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapOrganizer.php
@@ -12,10 +12,11 @@ class MapOrganizer extends AbstractAxiellEventsDataMapper
     public function map(Event $event, array $data): Event
     {
         $location = $data['location']['value'] ?? null;
-        return empty($location) ? $event : $event
-            ->organizer([
-                Schema::organization()
-                    ->name($location)
-            ]);
+        return $event->organizer(
+            array_values(
+                array_filter([
+                    empty($location) ? null : Schema::organization()->name($location)],)
+            )
+        );
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapPhysicalAccessibilityFeatures.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapPhysicalAccessibilityFeatures.php
@@ -6,11 +6,10 @@ namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
 
 use Municipio\Schema\Event;
 
-class MapName extends AbstractAxiellEventsDataMapper
+class MapPhysicalAccessibilityFeatures extends AbstractAxiellEventsDataMapper
 {
     public function map(Event $event, array $data): Event
     {
-        return $event
-            ->name($data['title'] ?? null);
+        return $event->physicalAccessibilityFeatures([]);
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapPotentialAction.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapPotentialAction.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapPotentialAction extends AbstractAxiellEventsDataMapper
+{
+    public function map(Event $event, array $data): Event
+    {
+        return $event->potentialAction([]);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapStartDate.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapStartDate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapStartDate extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event
+            ->startDate($data['startDate'] ?? null);
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapUrl.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapUrl.php
@@ -20,7 +20,7 @@ class MapUrl extends AbstractAxiellEventsDataMapper
     {
         return empty($this->externalBaseUrl)
             ? $event
-            : $event->url($this->externalBaseUrl . '/evenemang#/events/' . ($data['id'] ?? ''))
+            : $event->url($this->externalBaseUrl . ($data['id'] ?? ''))
         ;
     }
 }

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapUrl.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapUrl.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapUrl extends AbstractAxiellEventsDataMapper
+{
+    private string $externalBaseUrl;
+
+    public function __construct(string $externalBaseUrl)
+    {
+        parent::__construct();
+        $this->externalBaseUrl = $externalBaseUrl;
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return empty($this->externalBaseUrl)
+            ? $event
+            : $event->url($this->externalBaseUrl . '/evenemang#/events/' . ($data['id'] ?? ''))
+        ;
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/MapXCreatedBy.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/MapXCreatedBy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers;
+
+use Municipio\Schema\Event;
+
+class MapXCreatedBy extends AbstractAxiellEventsDataMapper
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function map(Event $event, array $data): Event
+    {
+        return $event->setProperty('x-created-by', 'municipio://schema.org-transformer/axiell-events');
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapDescriptionTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapDescriptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapDescription;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapDescription::class)]
+final class MapDescriptionTest extends TestCase
+{
+    #[TestDox('event::description is constructed from $.description')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapDescription(),
+            '{
+                "description": "Test event description"
+            }',
+            Schema::event()->description(['Test event description'])
+        );
+    }
+
+    #[TestDox('event::description([]) when $.description is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapDescription(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->description([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEndDateTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEndDateTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEndDate;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapEndDate::class)]
+final class MapEndDateTest extends TestCase
+{
+    #[TestDox('event::endDate is taken from $.endDate')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEndDate(),
+            '{
+                "endDate": "2024-06-01T12:00:00Z"
+            }',
+            Schema::event()->endDate('2024-06-01T12:00:00Z')
+        );
+    }
+
+    #[TestDox('event::endDate(null) when $.endDate is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEndDate(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->endDate(null)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventAttendanceModeTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventAttendanceModeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventAttendanceMode;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapEventAttendanceMode::class)]
+final class MapEventAttendanceModeTest extends TestCase
+{
+    #[TestDox('event::attendanceMode(https://schema.org/OfflineEventAttendanceMode) hardcoded')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEventAttendanceMode(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->eventAttendanceMode('https://schema.org/OfflineEventAttendanceMode')
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventScheduleTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventScheduleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventSchedule;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapEventSchedule::class)]
+final class MapEventScheduleTest extends TestCase
+{
+    #[TestDox('event::eventSchedule is constructed from $.startDate and $.endDate')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEventSchedule(),
+            '{
+                "startDate": "2024-09-01T19:00:00",
+                "endDate": "2024-09-01T21:00:00"
+            }',
+            Schema::event()->eventSchedule([
+                Schema::schedule()
+                    ->startDate('2024-09-01T19:00:00')
+                    ->endDate('2024-09-01T21:00:00')
+            ])
+        );
+    }
+
+    #[TestDox('event::eventSchedule([]) when $.startDate or $.endDate is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEventSchedule(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->eventSchedule([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventStatusTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapEventStatusTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapEventStatus;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapEventStatus::class)]
+final class MapEventStatusTest extends TestCase
+{
+    #[TestDox('event::eventStatus(Scheduled) is hardcoded')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEventStatus(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->eventStatus(Schema::eventStatusType()::EventScheduled)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapIdentifierTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapIdentifierTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\AxiellEventTransform;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIdentifier;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapIdentifier::class)]
+final class MapIdentifierTest extends TestCase
+{
+    #[TestDox('event::identifier is taken from $.id')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapIdentifier(new AxiellEventTransform('ax-', 'https://example.com/events/')),
+            '{
+                "id": "12345"
+            }',
+            Schema::event()->identifier('ax-12345')
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapImageTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapImageTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapImage;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapImage::class)]
+final class MapImageTest extends TestCase
+{
+    #[TestDox('event::image is taken from $.images')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapImage(),
+            '{
+                "images": [{
+                    "imageUrl": "https://example.com/image.jpg",
+                    "imageCaption": "Example image caption"
+                },
+                {
+                    "imageUrl": "https://example.com/image2.jpg"
+                },
+                {
+                    "imageCaption": "no url so skip this"
+                }]
+            }',
+            Schema::event()->image([
+                Schema::imageObject()
+                    ->url('https://example.com/image.jpg')
+                    ->description('Example image caption')
+                    ->caption('Example image caption'),
+                Schema::imageObject()
+                    ->url('https://example.com/image2.jpg')
+                    ->description(null)
+                    ->caption(null)
+            ])
+        );
+    }
+
+    #[TestDox('event::image([]) when $.images is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapImage(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->image([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapIsAccessibleForFreeTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapIsAccessibleForFreeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapIsAccessibleForFree;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapIsAccessibleForFree::class)]
+final class MapIsAccessibleForFreeTest extends TestCase
+{
+    #[TestDox('event::isAccessibleForFree(true) is hardcoded')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapIsAccessibleForFree(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->isAccessibleForFree(true)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapKeywordsTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapKeywordsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapKeywords;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapKeywords::class)]
+final class MapKeywordsTest extends TestCase
+{
+    #[TestDox('event::keywords is taken from $.tags')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapKeywords(),
+            '{
+                "tags": ["tag1", "tag2"]
+            }',
+            Schema::event()->keywords([
+                Schema::definedTerm()
+                        ->name('tag1')
+                        ->inDefinedTermSet(Schema::definedTermSet()->name('tags')),
+                Schema::definedTerm()
+                        ->name('tag2')
+                        ->inDefinedTermSet(Schema::definedTermSet()->name('tags'))
+            ])
+        );
+    }
+
+    #[TestDox('event::keywords([]) when $.tags is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapKeywords(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->keywords([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapLocationTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapLocationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapLocation;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapLocation::class)]
+final class MapLocationTest extends TestCase
+{
+    #[TestDox('event::location is taken from $.location and $.room')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapLocation(),
+            '{
+                "location": {
+                    "value": "Some Location"
+                },
+                "room": {
+                    "value": "Some Room"
+                }
+            }',
+            Schema::event()->location([Schema::place()->name('Some Location')->description('Some Room')])
+        );
+    }
+
+    #[TestDox('event::location is taken from $.location')]
+    public function testLocationOnly()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapLocation(),
+            '{
+                "location": {
+                    "value": "Some Location"
+                }
+            }',
+            Schema::event()->location([Schema::place()->name('Some Location')->description(null)])
+        );
+    }
+
+    #[TestDox('event::location(null) when $.location is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapLocation(),
+            '{
+                "id": 123,
+                "room": {
+                    "value": "Some Room"
+                }
+            }',
+            Schema::event()->location([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapNameTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapNameTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapName;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapName::class)]
+final class MapNameTest extends TestCase
+{
+    #[TestDox('event::name is taken from $.title')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapName(),
+            '{
+                "title": "Some Event Name"
+            }',
+            Schema::event()->name('Some Event Name')
+        );
+    }
+
+    #[TestDox('event::name(null) when $.title is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapName(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->name(null)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapOffersTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapOffersTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOffers;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapOffers::class)]
+final class MapOffersTest extends TestCase
+{
+    #[TestDox('event::offers([]) is hardcoded')]
+    public function testItsHardCoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapOffers(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->offers([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapOrganizerTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapOrganizerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapOrganizer;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapOrganizer::class)]
+final class MapOrganizerTest extends TestCase
+{
+    #[TestDox('event::organizer is taken from $.location')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapOrganizer(),
+            '{
+                "location": {
+                    "value": "Some Organizer"
+                }
+            }',
+            Schema::event()->organizer([
+                Schema::organization()->name('Some Organizer')
+            ])
+        );
+    }
+
+    #[TestDox('event::organizer([]) when $.location is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapOrganizer(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->organizer([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapPhysicalAccessibilityFeaturesTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapPhysicalAccessibilityFeaturesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPhysicalAccessibilityFeatures;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapPhysicalAccessibilityFeatures::class)]
+final class MapPhysicalAccessibilityFeaturesTest extends TestCase
+{
+    #[TestDox('event::physicalAccessibilityFeatures([]) is hardcoded')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapPhysicalAccessibilityFeatures(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->physicalAccessibilityFeatures([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapPotentialActionTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapPotentialActionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapPotentialAction;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapPotentialAction::class)]
+final class MapPotentialActionTest extends TestCase
+{
+    #[TestDox('event::potentialAction([]) is hardcoded')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapPotentialAction(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->potentialAction([])
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapStartDateTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapStartDateTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapStartDate;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapStartDate::class)]
+final class MapStartDateTest extends TestCase
+{
+    #[TestDox('event::startDate is taken from $.startDate')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapStartDate(),
+            '{
+                "startDate": "2024-06-01T12:00:00Z"
+            }',
+            Schema::event()->startDate('2024-06-01T12:00:00Z')
+        );
+    }
+
+    #[TestDox('event::startDate(null) when $.startDate is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapStartDate(),
+            '{
+                "id": 123
+            }',
+            Schema::event()->startDate(null)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapUrlTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapUrlTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapUrl;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapUrl::class)]
+final class MapUrlTest extends TestCase
+{
+    #[TestDox('event::url is combination of base url and $.id')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapUrl('https://example.com/events/'),
+            '{
+                "id": "123"
+            }',
+            Schema::event()->url('https://example.com/events/123')
+        );
+    }
+
+    #[TestDox('event::url(null) when base url is empty')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapUrl(''),
+            '{
+                "id": 123
+            }',
+            Schema::event()->url(null)
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapXCreatedByTest.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/MapXCreatedByTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\MapXCreatedBy;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests\TestHelper;
+
+#[CoversClass(MapXCreatedBy::class)]
+final class MapXCreatedByTest extends TestCase
+{
+    #[TestDox('event::x-created-by is hardcoded to "municipio://schema.org-transformer/axiell-events"')]
+    public function testItsHardcoded()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapXCreatedBy(),
+            '{
+                "id": "123"
+            }',
+            Schema::event()->setProperty('x-created-by', 'municipio://schema.org-transformer/axiell-events')
+        );
+    }
+}

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/TestHelper.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/TestHelper.php
@@ -20,7 +20,7 @@ class TestHelper extends Assert
         AxiellEventsDataMapperInterface $mapper,
         string $sourceJson,
         Event $expectedEvent,
-        string $message = null
+        ?string $message = null
     ): TestHelper {
         $source = $this->prepareJsonForTransform($sourceJson);
         $this->assertNotEmpty($source, 'Source data is empty or invalid JSON');

--- a/src/Transforms/Event/AxiellEvents/Mappers/Tests/TestHelper.php
+++ b/src/Transforms/Event/AxiellEvents/Mappers/Tests/TestHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\Tests;
+
+use PHPUnit\Framework\Assert;
+use Municipio\Schema\Schema;
+use Municipio\Schema\Event;
+use SchemaTransformer\Transforms\Event\AxiellEvents\Mappers\AxiellEventsDataMapperInterface;
+
+class TestHelper extends Assert
+{
+    protected function prepareJsonForTransform($json)
+    {
+        return json_decode($json, true);
+    }
+
+    public function expectMapperToConvertSourceTo(
+        AxiellEventsDataMapperInterface $mapper,
+        string $sourceJson,
+        Event $expectedEvent,
+        string $message = null
+    ): TestHelper {
+        $source = $this->prepareJsonForTransform($sourceJson);
+        $this->assertNotEmpty($source, 'Source data is empty or invalid JSON');
+
+        $actual = $mapper->map(Schema::event(), $source);
+
+        $this->assertEquals(
+            $expectedEvent->toArray(),
+            $actual->toArray(),
+            $message ?: 'Mapper did not produce expected output for given source'
+        );
+
+        return $this;
+    }
+}

--- a/src/Transforms/NullDataPreprocessor.php
+++ b/src/Transforms/NullDataPreprocessor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms;
+
+use SchemaTransformer\Interfaces\AbstractDataPreprocessor;
+
+class NullDataPreprocessor implements AbstractDataPreprocessor
+{
+    public function preprocessData(array $data): array
+    {
+        return $data;
+    }
+}

--- a/src/Transforms/TransformBase.php
+++ b/src/Transforms/TransformBase.php
@@ -12,6 +12,12 @@ abstract class TransformBase
     {
         $this->idprefix = $idprefix;
     }
+
+    public function preprocessData(array $data): array
+    {
+        return $data;
+    }
+
     public function formatId(string | int $value): string
     {
         return trim($this->idprefix . $value);

--- a/src/Transforms/WPExhibitionEventTransform.php
+++ b/src/Transforms/WPExhibitionEventTransform.php
@@ -18,6 +18,11 @@ class WPExhibitionEventTransform implements AbstractDataTransform
     {
     }
 
+    public function preprocessData(array $data): array
+    {
+        return $data;
+    }
+
     public function transform(array $data): array
     {
         return array_map(function ($item) {


### PR DESCRIPTION
This pull request introduces support for transforming Axiell events data, including the addition of a new `AxiellEventTransform` class, updates to the command-line interface to support new filtering options, and integration of a data preprocessing step for readers. It also adds scripts for running and importing Axiell events, and includes a test for the new transformer. The most important changes are grouped below.

**Axiell Events Transformation and Filtering**

* Added the `AxiellEventTransform` class, which implements filtering (by date, include/exclude tags) and mapping logic for Axiell events, as well as a corresponding test (`AxiellEventTransformTest`). [[1]](diffhunk://#diff-63edac97d3fb9c082bb4c170b81f194b67a0c5aa5fec65803fdba3d2c3fae9cfR1-R111) [[2]](diffhunk://#diff-0ebcdba1abd6bb23557bb8cbc1a3a3bbe6e9d3a90c2a5205f3b5aa989d2cd2daR1-R57)
* Integrated the new transformer into the service layer (`RuntimeServices`) and updated the CLI to support the `axiell_events` transform, including new options: `externalbaseurl`, `excludetags`, and `includetags`. [[1]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R22) [[2]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R34-R37) [[3]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R71-R80) [[4]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R116-R120) Ff75334eL21R21, [[5]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR44-R46) [[6]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL70-R75) [[7]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR207-R212)

**Data Preprocessing Architecture**

* Introduced the `AbstractDataPreprocessor` interface and updated `AbstractDataReader` and its implementations (`FileReader`, `HttpReader`) to accept a preprocessor, allowing data to be filtered and normalized before transformation. [[1]](diffhunk://#diff-48e8588c4f904097376d827f25cf6a1341415a807f9f46e1ab6cd28595602519R1-R10) [[2]](diffhunk://#diff-812c54b9b2853e9c229856da488d291cb637619d90390d761f97bb83ab6113a6L9-R9) [[3]](diffhunk://#diff-a650223cd72365cd635288f84231117c1d9ad1f910b0785ea9af8f5ff6b7432bR7-R19) [[4]](diffhunk://#diff-e203aa2bc95ff6f227ef9754b154614a68e115c11711ca70b6017b2ad0a8db4aR7) [[5]](diffhunk://#diff-e203aa2bc95ff6f227ef9754b154614a68e115c11711ca70b6017b2ad0a8db4aL25-R26) [[6]](diffhunk://#diff-e203aa2bc95ff6f227ef9754b154614a68e115c11711ca70b6017b2ad0a8db4aL35-R36) [[7]](diffhunk://#diff-49ab0835e294deb1272d2d2300187dbf07fa461253c8d1e0557a70802a0b96eaL7-R7) [[8]](diffhunk://#diff-2bc7ef04f0be56615bed37ba896e72817c25ed068c2c1339586b2a6f3aad41fdL34-R34) [[9]](diffhunk://#diff-34b2ef8ab0c5dec9741b43cf84fe15aefbff59f602c81f495223a48c669152d7R9) [[10]](diffhunk://#diff-34b2ef8ab0c5dec9741b43cf84fe15aefbff59f602c81f495223a48c669152d7L22-R23)

**Command-Line and Script Support**

* Added two scripts, `run.sh` and `run-local.sh`, for importing and transforming Axiell events data, including environment variable checks, data retrieval, and posting to Typesense. [[1]](diffhunk://#diff-9d069dce838b96c2b1fbf976180aa911fa7a299c0d80f323e165b04764ef3ac0R1-R63) [[2]](diffhunk://#diff-0ecf248776fe1709e1533bf9b2c639b778513c2f38089652fa37e0338b66df4eR1-R25)
* Updated the CLI help and default options to include new parameters relevant for Axiell events. [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR44-R46) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL70-R75) Ff75334eL21R21, [[3]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR207-R212)

**Service Layer and Execution Flow**

* Updated the `Service` and `RuntimeServices` classes to pass the transformer as a data preprocessor, ensuring filtering and mapping occurs during data reading and transformation. [[1]](diffhunk://#diff-2bc7ef04f0be56615bed37ba896e72817c25ed068c2c1339586b2a6f3aad41fdL34-R34) [[2]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R71-R80)

**Configuration and Routing**

* Extended the `router.php` configuration to accept the new Axiell events-related parameters.

These changes collectively enable robust support for transforming, filtering, and importing Axiell events data into the system.