### PR TITLE
Pios project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 /coverage
 .env
 *.local
+.local/

--- a/scripts/pios-project/run-local.sh
+++ b/scripts/pios-project/run-local.sh
@@ -1,0 +1,57 @@
+# !/bin/bash
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+if [ -z ${PIOS_API_KEY} ]; then
+    echo "Missing env variable PIOS_API_KEY"; exit 1
+fi
+which php >/dev/null
+if [ $? -ne 0 ]; then
+    echo "PHP command missing or not in path"; exit 1
+fi
+cd ${SCRIPT_DIR}
+
+# Fetch paginated data from PIOS API and transform it as if coming from a single request
+function fetch_paginated() {
+     pageNumber=1
+     pageSize=100
+
+     # loop over pages
+     while :; do
+          # fetch a response like {"records":[...],"totalRecords":123}
+          response=$(curl \
+               -sb \
+               --header "Accept: text/plain" \
+               --header "ApiKey: ${PIOS_API_KEY}" \
+               --request GET \
+               "https://pios.dimatech.se/api/pios/public/projects?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
+
+          # stop when no records are returned
+          if jq -e '.records | length == 0' >/dev/null <<<"$response"; then
+               break
+          fi
+
+          echo "$response"
+          pageNumber=$((pageNumber + 1))
+     done | jq -s '
+          {
+               records: ([.[].records] | add),
+               totalRecords: (.[0].totalRecords)
+          }
+          ' # combine all records into a single array and take totalRecords from the first response
+}
+
+tmp=$(mktemp)
+echo $(fetch_paginated) >> "$tmp"
+
+php ../../router.php \
+    --source "$tmp" \
+    --transform pios_project \
+    --outputformat json \
+    --idprefix ax-
+
+if [ $? -ne 0 ]; then
+    echo "FAILED to transform request"
+fi
+
+rm "$tmp"

--- a/scripts/pios-project/run-local.sh
+++ b/scripts/pios-project/run-local.sh
@@ -48,7 +48,7 @@ php ../../router.php \
     --source "$tmp" \
     --transform pios_project \
     --outputformat json \
-    --idprefix ax-
+    --idprefix pios-
 
 if [ $? -ne 0 ]; then
     echo "FAILED to transform request"

--- a/scripts/pios-project/run-local.sh
+++ b/scripts/pios-project/run-local.sh
@@ -24,7 +24,7 @@ function fetch_paginated() {
                --header "Accept: text/plain" \
                --header "ApiKey: ${PIOS_API_KEY}" \
                --request GET \
-               "https://pios.dimatech.se/api/pios/public/projects?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
+               "https://pios.dimatech.se/api/pios/public/projects/extended?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
 
           # stop when no records are returned
           if jq -e '.records | length == 0' >/dev/null <<<"$response"; then

--- a/scripts/pios-project/run.sh
+++ b/scripts/pios-project/run.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+TYPESENSE_PATH=${TYPESENSE_BASE_PATH}/collections/pios-projects/documents
+
+if [ -z ${PIOS_API_KEY} ]; then
+    echo "Missing env variable PIOS_API_KEY"; exit 1
+fi
+which php >/dev/null
+if [ $? -ne 0 ]; then
+    echo "PHP command missing or not in path"; exit 1
+fi
+cd ${SCRIPT_DIR}
+
+
+# Fetch paginated data from PIOS API and transform it as if coming from a single request
+function fetch_paginated() {
+     pageNumber=1
+     pageSize=100
+
+     # loop over pages
+     while :; do
+          # fetch a response like {"records":[...],"totalRecords":123}
+          response=$(curl \
+               -sb \
+               --header "Accept: text/plain" \
+               --header "ApiKey: ${PIOS_API_KEY}" \
+               --request GET \
+               "https://pios.dimatech.se/api/pios/public/projects?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
+
+          # stop when no records are returned
+          if jq -e '.records | length == 0' >/dev/null <<<"$response"; then
+               break
+          fi
+
+          echo "$response"
+          pageNumber=$((pageNumber + 1))
+     done | jq -s '
+          {
+               records: ([.[].records] | add),
+               totalRecords: (.[0].totalRecords)
+          }
+          ' # combine all records into a single array and take totalRecords from the first response
+}
+
+(
+    flock -n 9 || exit 1
+
+    TMPFILE=$(mktemp)
+    tmpsource=$(mktemp)
+    echo $(fetch_paginated) >> "$tmpsource"
+    php ../../router.php \
+        --source "$tmpsource" \
+        --transform pios_project \
+        --outputformat jsonl \
+        --idprefix pios- \
+        --output ${TMPFILE}
+
+    rm -f "$tmpsource"
+
+    if [ $? -ne 0 ]; then
+        echo "FAILED to transform request"
+    else
+        # Clear collection
+        echo "Deleting documents"
+        curl -X DELETE \
+            -H "x-typesense-api-key: ${TYPESENSE_APIKEY}" \
+            -H "Content-Type: application/json" \
+            "${TYPESENSE_BASE_PATH}/collections/pios-projects/documents?filter_by=x-created-by:=municipio%3A%2F%2Fschema.org-transformer%2Fpios-project"
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to delete documents"
+        fi
+
+        # POST result to typesense
+        echo "Creating documents"
+        curl ${TYPESENSE_PATH}/import?action=create -X POST --data-binary @${TMPFILE} -H "Content-Type: text/plain" -H "x-typesense-api-key: ${TYPESENSE_APIKEY}"
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to upload document"
+        fi
+
+        # Clear typesense cache
+        echo "Clearing Typesense cache"
+        curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_APIKEY}" -X POST ${TYPESENSE_BASE_PATH}/operations/cache/clear
+
+        if [ $? -ne 0 ]; then
+            echo "FAILED to clear Typesense cache"
+        else
+            # Call monitoring url if set
+            if [ -n "$TIX_EVENTS_MONITOR_URL" ]; then curl -s "$TIX_EVENTS_MONITOR_URL" >/dev/null; fi
+        fi
+
+    fi
+    # Remove temp file
+    rm -f ${TMPFILE}
+) 9>/tmp/pios-projects.lock

--- a/scripts/pios-project/run.sh
+++ b/scripts/pios-project/run.sh
@@ -25,7 +25,7 @@ function fetch_paginated() {
                --header "Accept: text/plain" \
                --header "ApiKey: ${PIOS_API_KEY}" \
                --request GET \
-               "https://pios.dimatech.se/api/pios/public/projects?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
+               "https://pios.dimatech.se/api/pios/public/projects/extended?filter.readyForExportOnly=false&pageNumber=${pageNumber}&pageSize=${pageSize}")
 
           # stop when no records are returned
           if jq -e '.records | length == 0' >/dev/null <<<"$response"; then

--- a/src/App.php
+++ b/src/App.php
@@ -210,6 +210,12 @@ class App
                     $cmd->output
                 );
                 break;
+            case 'pios_project':
+                $result = $services->getPiosProjectService()->execute(
+                    $cmd->source,
+                    $cmd->output
+                );
+                break;
             default:
                 printf('Missing transform for (%s)\n', $cmd->transform);
                 break;

--- a/src/Services/RuntimeServices.php
+++ b/src/Services/RuntimeServices.php
@@ -20,6 +20,7 @@ use SchemaTransformer\Transforms\Event\TixEvents\TixEventTransform;
 use SchemaTransformer\Transforms\Event\WPLegacyEvents\WPLegacyEventTransform;
 use SchemaTransformer\Transforms\Event\WPHeadLessEvents\WPHeadlessEventTransform;
 use SchemaTransformer\Transforms\Event\AxiellEvents\AxiellEventTransform;
+use SchemaTransformer\Transforms\PiosProject\PiosProjectTransform;
 
 class RuntimeServices
 {
@@ -32,6 +33,7 @@ class RuntimeServices
     private AbstractService $preSchoolService;
     private AbstractService $tixEventService;
     private AbstractService $axiellEventsService;
+    private AbstractService $piosProjectService;
 
     public function __construct(
         object $commandlineOptions,
@@ -78,6 +80,7 @@ class RuntimeServices
                 preg_split("/\s*,\s*/", $commandlineOptions->includetags ?? '')
             ))
         ), $converter);
+        $this->piosProjectService       = new Service($reader, $writer, new PiosProjectTransform($idprefix), $converter);
     }
 
     public function getJobPostingService(): AbstractService
@@ -117,5 +120,10 @@ class RuntimeServices
     public function getAxiellEventsService(): AbstractService
     {
         return $this->axiellEventsService;
+    }
+
+    public function getPiosProjectService(): AbstractService
+    {
+        return $this->piosProjectService;
     }
 }

--- a/src/Transforms/PiosProject/Mappers/AbstractPiosProjectMapper.php
+++ b/src/Transforms/PiosProject/Mappers/AbstractPiosProjectMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+use SchemaTransformer\Transforms\TransformBase;
+
+abstract class AbstractPiosProjectMapper implements PiosProjectMapperInterface
+{
+    public function __construct(private ?TransformBase $transform = null)
+    {
+    }
+
+    abstract public function map(Project $project, array $data): Project;
+
+    protected function formatId(string | int $value): string
+    {
+        return $this->transform->formatId($value);
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapDepartment.php
+++ b/src/Transforms/PiosProject/Mappers/MapDepartment.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Project;
+
+class MapDepartment extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        $entityName = $data['entityName'] ?? null;
+        return $entityName
+            ? $project->department(Schema::organization()->name($entityName))
+            : $project;
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapDescription.php
+++ b/src/Transforms/PiosProject/Mappers/MapDescription.php
@@ -13,28 +13,36 @@ class MapDescription extends AbstractPiosProjectMapper
     public function map(Project $project, array $data): Project
     {
         $sections = [
-            Schema::textObject()->text($data['description'] ?? '')->name('Beskrivning'),
+            $this->makeSection($data['description'] ?? null, 'description'),
+            $this->makeSection($data['benefitsAndEffects'] ?? null, 'benefitsAndEffects', '<h2>Nyttor och effekter</h2>'),
             $this->makeBulletSection(
-                'Mål',
                 array_filter(array_values(array_map(
                     fn($goal) => $goal['name'] ?? null,
                     $data['goals'] ?? []
-                )))
+                ))),
+                'goals',
+                '<h2>Mål</h2>'
             ),
 
             $this->makeBulletSection(
-                'Risker',
                 array_filter(array_values(array_map(
                     fn($risk) => $risk['description'] ?? null,
                     $data['risks'] ?? []
-                )))
+                ))),
+                'risks',
+                '<h2>Risker</h2>'
             )
         ];
 
         return $project->description(array_values(array_filter($sections)));
     }
 
-    private function makeBulletSection(string $name, array $items): TextObject|null
+    private function makeSection(?string $text, string $name, ?string $headline = null): TextObject|null
+    {
+        return empty($text) ? null : Schema::textObject()->text($text)->headline($headline)->name($name);
+    }
+
+    private function makeBulletSection(array $items, ?string $name = null, ?string $headline = null): TextObject|null
     {
         if (empty($items)) {
             return null;
@@ -45,6 +53,6 @@ class MapDescription extends AbstractPiosProjectMapper
             $result .= "<li>{$item}</li>";
         }
         $result .= '</ul>';
-        return Schema::textObject()->text($result)->headline($name)->name($name);
+        return Schema::textObject()->text($result)->headline($headline)->name($name);
     }
 }

--- a/src/Transforms/PiosProject/Mappers/MapDescription.php
+++ b/src/Transforms/PiosProject/Mappers/MapDescription.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+use Municipio\Schema\TextObject;
+use Municipio\Schema\Schema;
+
+class MapDescription extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        $sections = [
+            Schema::textObject()->text($data['description'] ?? '')->name('Beskrivning'),
+            $this->makeBulletSection(
+                'Mål',
+                array_filter(array_values(array_map(
+                    fn($goal) => $goal['name'] ?? null,
+                    $data['goals'] ?? []
+                )))
+            ),
+
+            $this->makeBulletSection(
+                'Risker',
+                array_filter(array_values(array_map(
+                    fn($risk) => $risk['description'] ?? null,
+                    $data['risks'] ?? []
+                )))
+            )
+        ];
+
+        return $project->description(array_values(array_filter($sections)));
+    }
+
+    private function makeBulletSection(string $name, array $items): TextObject|null
+    {
+        if (empty($items)) {
+            return null;
+        }
+        // $result = "<h2>{$name}</h2><ul>";
+        $result = "<ul>";
+        foreach ($items as $item) {
+            $result .= "<li>{$item}</li>";
+        }
+        $result .= '</ul>';
+        return Schema::textObject()->text($result)->headline($name)->name($name);
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapDescription.php
+++ b/src/Transforms/PiosProject/Mappers/MapDescription.php
@@ -24,6 +24,18 @@ class MapDescription extends AbstractPiosProjectMapper
                 '<h2>Mål</h2>'
             ),
 
+            ...array_filter(
+                array_map(
+                    fn($dim) => $this->makeBulletSection(
+                        $dim['values'] ?? [],
+                        null,
+                        "<h2>{$dim['name']}</h2>",
+                        $dim['value'] ?? null
+                    ),
+                    $data['customDimensions'] ?? []
+                )
+            ),
+/*
             $this->makeBulletSection(
                 array_filter(array_values(array_map(
                     fn($risk) => $risk['description'] ?? null,
@@ -32,6 +44,7 @@ class MapDescription extends AbstractPiosProjectMapper
                 'risks',
                 '<h2>Risker</h2>'
             )
+*/
         ];
 
         return $project->description(array_values(array_filter($sections)));
@@ -42,17 +55,20 @@ class MapDescription extends AbstractPiosProjectMapper
         return empty($text) ? null : Schema::textObject()->text($text)->headline($headline)->name($name);
     }
 
-    private function makeBulletSection(array $items, ?string $name = null, ?string $headline = null): TextObject|null
+    private function makeBulletSection(array $items, ?string $name = null, ?string $headline = null, ?string $preface = null): TextObject|null
     {
-        if (empty($items)) {
+        if (empty($items) && empty($preface)) {
             return null;
         }
-        // $result = "<h2>{$name}</h2><ul>";
-        $result = "<ul>";
-        foreach ($items as $item) {
-            $result .= "<li>{$item}</li>";
+
+        $result = $preface ?? '';
+        if (!empty($items)) {
+            $result .= "<ul>";
+            foreach ($items as $item) {
+                $result .= "<li>{$item}</li>";
+            }
+            $result .= '</ul>';
         }
-        $result .= '</ul>';
         return Schema::textObject()->text($result)->headline($headline)->name($name);
     }
 }

--- a/src/Transforms/PiosProject/Mappers/MapEmployee.php
+++ b/src/Transforms/PiosProject/Mappers/MapEmployee.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+use Municipio\Schema\Schema;
+
+class MapEmployee extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        // NOTE: Mapping to array differs from Stratsys
+        return $project->employee(
+            array_values(
+                array_filter(
+                    array_map(
+                        fn($member) => Schema::person()->description($member['role'] ?? '')->email($member['email'] ?? ''),
+                        $data['teamMembers'] ?? []
+                    ),
+                    fn($person) => !empty($person->getProperty('email'))
+                )
+            )
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapEmployee.php
+++ b/src/Transforms/PiosProject/Mappers/MapEmployee.php
@@ -16,8 +16,8 @@ class MapEmployee extends AbstractPiosProjectMapper
             array_values(
                 array_filter(
                     array_map(
-                        fn($member) => Schema::person()->description($member['role'] ?? '')->email($member['email'] ?? ''),
-                        $data['teamMembers'] ?? []
+                        fn($member) => $member ?? null ? Schema::person()->email($member ?? '') : null,
+                        $data['projectManagers'] ?? []
                     ),
                     fn($person) => !empty($person->getProperty('email'))
                 )

--- a/src/Transforms/PiosProject/Mappers/MapFoundingDate.php
+++ b/src/Transforms/PiosProject/Mappers/MapFoundingDate.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+
+class MapFoundingDate extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        return $project->foundingDate($data['startYear'] ?? '');
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapFunding.php
+++ b/src/Transforms/PiosProject/Mappers/MapFunding.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Project;
+
+class MapFunding extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        // NOTE: Mapping to array differs from Stratsys
+        return $project->funding(
+            array_values(
+                array_filter(
+                    array_map(
+                        fn($period) => $period['amount'] ?? null
+                        ? Schema::monetaryGrant()->name($period['year'] ?? '')->amount($period['amount'] ?? 0)
+                        : null,
+                        $data['periods'] ?? []
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapFunding.php
+++ b/src/Transforms/PiosProject/Mappers/MapFunding.php
@@ -16,8 +16,8 @@ class MapFunding extends AbstractPiosProjectMapper
             array_values(
                 array_filter(
                     array_map(
-                        fn($period) => $period['amount'] ?? null
-                        ? Schema::monetaryGrant()->name($period['year'] ?? '')->amount($period['amount'] ?? 0)
+                        fn($period) => $period['totalBudget'] ?? null
+                        ? Schema::monetaryGrant()->name($period['year'] ?? '')->amount($period['totalBudget'] ?? 0)
                         : null,
                         $data['periods'] ?? []
                     )

--- a/src/Transforms/PiosProject/Mappers/MapIdentifier.php
+++ b/src/Transforms/PiosProject/Mappers/MapIdentifier.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+use SchemaTransformer\Transforms\TransformBase;
+
+class MapIdentifier extends AbstractPiosProjectMapper
+{
+    public function __construct(private ?TransformBase $transform)
+    {
+        parent::__construct($transform);
+    }
+
+    public function map(Project $project, array $data): Project
+    {
+        // Implement the mapping logic here
+        return $project->identifier($this->formatId($data['projectId'] ?? ''));
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapKeywords.php
+++ b/src/Transforms/PiosProject/Mappers/MapKeywords.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Project;
+
+class MapKeywords extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        return $project->keywords(
+            array_values(array_filter(
+                array_map(
+                    fn($tag) => $tag['displayName'] ?? null
+                        ? Schema::definedTerm()
+                            ->name($tag['displayName'] ?? null)
+                            ->inDefinedTermSet(Schema::definedTermSet()->name('tags'))
+                        : null,
+                    $data['tags'] ?? []
+                )
+            ))
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapName.php
+++ b/src/Transforms/PiosProject/Mappers/MapName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+
+class MapName extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        return $project->name($data['title'] ?? '');
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapStatus.php
+++ b/src/Transforms/PiosProject/Mappers/MapStatus.php
@@ -11,16 +11,16 @@ class MapStatus extends AbstractPiosProjectMapper
 {
     private array $phases = [
         'NotSet'                             => 'Ingen status',
-        'Draft'                              => 'Utkast',
-        'Ready'                              => 'Redo',
+        'Draft'                              => 'Projektidé, utkast',
+        'Ready'                              => 'Projektidé, färdigt utkast',
         'ReadyForReview'                     => 'Redo för granskning',
-        'Published'                          => 'Publicerad',
-        'NotStartedDecided'                  => 'Ej startad',
-        'Started'                            => 'Startad',
-        'Finished'                           => 'Avslutad',
+        'Published'                          => 'Projektidé, publicerad',
+        'NotStartedDecided'                  => 'Ej påbörjad, beslutad',
+        'Started'                            => 'Pågående',
+        'Finished'                           => 'Slutförd, effekthemtagning avslutad',
         'Paused'                             => 'Pausad',
-        'FinishedEffectRealizationStarted'   => 'Inväntar effekthemtagning',
-        'FinishedEffectRealizationConcluded' => 'Effekthemtagning avslutad'
+        'FinishedEffectRealizationStarted'   => 'Slutförd, effekthemtagning pågår',
+        'FinishedEffectRealizationConcluded' => 'Slutförd, effekthemtagning avslutad'
     ];
 
     private array $statuses = [

--- a/src/Transforms/PiosProject/Mappers/MapStatus.php
+++ b/src/Transforms/PiosProject/Mappers/MapStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Schema;
+use Municipio\Schema\Project;
+
+class MapStatus extends AbstractPiosProjectMapper
+{
+    private array $phases = [
+        'NotSet'                             => 'Ingen status',
+        'Draft'                              => 'Utkast',
+        'Ready'                              => 'Redo',
+        'ReadyForReview'                     => 'Redo för granskning',
+        'Published'                          => 'Publicerad',
+        'NotStartedDecided'                  => 'Ej startad',
+        'Started'                            => 'Startad',
+        'Finished'                           => 'Avslutad',
+        'Paused'                             => 'Pausad',
+        'FinishedEffectRealizationStarted'   => 'Inväntar effekthemtagning',
+        'FinishedEffectRealizationConcluded' => 'Effekthemtagning avslutad'
+    ];
+
+    private array $statuses = [
+        'Zero'  => 0,
+        'One'   => 33,
+        'Two'   => 66,
+        'Three' => 100
+    ];
+
+    public function map(Project $project, array $data): Project
+    {
+        return $project->status(
+            Schema::progressStatus()
+                ->minNumber(0)
+                ->maxNumber(100)
+                ->name($this->phases[$data['projectPhase'] ?? 'NotSet'] ?? null)
+                ->number($this->statuses[$data['projectStatus'] ?? 'Zero'] ?? 0)
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/MapXCreatedBy.php
+++ b/src/Transforms/PiosProject/Mappers/MapXCreatedBy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+
+class MapXCreatedBy extends AbstractPiosProjectMapper
+{
+    public function map(Project $project, array $data): Project
+    {
+        return $project->setProperty('x-created-by', 'municipio://schema.org-transformer/pios-project');
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/PiosProjectMapperInterface.php
+++ b/src/Transforms/PiosProject/Mappers/PiosProjectMapperInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers;
+
+use Municipio\Schema\Project;
+
+interface PiosProjectMapperInterface
+{
+    public function map(Project $project, array $data): Project;
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapDepartmentTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapDepartmentTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapDepartment;
+
+#[CoversClass(MapDepartment::class)]
+final class MapDepartmentTest extends TestCase
+{
+    #[TestDox('project::department is take from entityName')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapDepartment(),
+            '{
+                "entityName": "Test department"
+            }',
+            Schema::project()->department(
+                Schema::organization()->name('Test department')
+            )
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapDescriptionTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapDescriptionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapDescription;
+
+#[CoversClass(MapDescription::class)]
+final class MapDescriptionTest extends TestCase
+{
+    #[TestDox('project::description is taken from description, benefitsAndEffects, goals and risks')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapDescription(),
+            '{
+                "description": "Test description",
+                "benefitsAndEffects": "Test benefits and effects",
+                "goals": [{"name": "Goal 1"}, {"name": "Goal 2"}, {"name": null}, {}, null],
+                "risks": [{"description": "Risk 1"}, {"description": "Risk 2"}, {"description": null}, {}, null]
+            }',
+            Schema::project()->description([
+                Schema::textObject()->text("Test description")->name('description'),
+                Schema::textObject()->text("Test benefits and effects")->headline('<h2>Nyttor och effekter</h2>')->name('benefitsAndEffects'),
+                Schema::textObject()->text("<ul><li>Goal 1</li><li>Goal 2</li></ul>")->headline('<h2>Mål</h2>')->name('goals'),
+                Schema::textObject()->text("<ul><li>Risk 1</li><li>Risk 2</li></ul>")->headline('<h2>Risker</h2>')->name('risks')
+            ])
+        );
+    }
+
+    #[TestDox('project::description([]) if no data is present')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapDescription(),
+            '{"id": 123}',
+            Schema::project()->description([])
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapDescriptionTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapDescriptionTest.php
@@ -13,7 +13,7 @@ use SchemaTransformer\Transforms\PiosProject\Mappers\MapDescription;
 #[CoversClass(MapDescription::class)]
 final class MapDescriptionTest extends TestCase
 {
-    #[TestDox('project::description is taken from description, benefitsAndEffects, goals and risks')]
+    #[TestDox('project::description is taken from description, benefitsAndEffects, goals and customDimensions')]
     public function testItWorks()
     {
         (new TestHelper())->expectMapperToConvertSourceTo(
@@ -22,13 +22,27 @@ final class MapDescriptionTest extends TestCase
                 "description": "Test description",
                 "benefitsAndEffects": "Test benefits and effects",
                 "goals": [{"name": "Goal 1"}, {"name": "Goal 2"}, {"name": null}, {}, null],
-                "risks": [{"description": "Risk 1"}, {"description": "Risk 2"}, {"description": null}, {}, null]
+                "risks": [{"description": "Risk 1"}, {"description": "Risk 2"}, {"description": null}, {}, null],
+                "customDimensions": [
+                    {
+                        "name": "Beskrivning av status",
+                        "value": "En statusbeskrivning av projektet.",
+                        "values": null
+                    },
+                    {
+                        "name": "Prioriterade områden VP",
+                        "values": ["Område 1", "Område 2"]
+                    }
+                ]
             }',
             Schema::project()->description([
                 Schema::textObject()->text("Test description")->name('description'),
                 Schema::textObject()->text("Test benefits and effects")->headline('<h2>Nyttor och effekter</h2>')->name('benefitsAndEffects'),
                 Schema::textObject()->text("<ul><li>Goal 1</li><li>Goal 2</li></ul>")->headline('<h2>Mål</h2>')->name('goals'),
-                Schema::textObject()->text("<ul><li>Risk 1</li><li>Risk 2</li></ul>")->headline('<h2>Risker</h2>')->name('risks')
+
+                Schema::textObject()->text("En statusbeskrivning av projektet.")->headline('<h2>Beskrivning av status</h2>')->name(null),
+                Schema::textObject()->text("<ul><li>Område 1</li><li>Område 2</li></ul>")->headline('<h2>Prioriterade områden VP</h2>')->name(null),
+                // Schema::textObject()->text("<ul><li>Risk 1</li><li>Risk 2</li></ul>")->headline('<h2>Risker</h2>')->name('risks')
             ])
         );
     }

--- a/src/Transforms/PiosProject/Mappers/Tests/MapEmployeeTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapEmployeeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapEmployee;
+
+#[CoversClass(MapEmployee::class)]
+final class MapEmployeeTest extends TestCase
+{
+    #[TestDox('project::name is take from teamMembers')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEmployee(),
+            '{
+                "teamMembers": [
+                    {
+                        "email": "p@example.com",
+                        "role": "Project manager"
+                    }
+                ]
+            }',
+            Schema::project()->employee([
+                Schema::person()->email('p@example.com')->description('Project manager')
+            ])
+        );
+    }
+
+    #[TestDox('project::employee is empty when teamMembers is empty')]
+    public function testEmpty()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEmployee(),
+            '{
+                "teamMembers": []
+            }',
+            Schema::project()->employee([])
+        );
+    }
+
+    #[TestDox('project::employee is empty when teamMembers is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapEmployee(),
+            '{"id":123}',
+            Schema::project()->employee([])
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapEmployeeTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapEmployeeTest.php
@@ -13,38 +13,34 @@ use SchemaTransformer\Transforms\PiosProject\Mappers\MapEmployee;
 #[CoversClass(MapEmployee::class)]
 final class MapEmployeeTest extends TestCase
 {
-    #[TestDox('project::name is take from teamMembers')]
+    #[TestDox('project::employee is taken from projectManagers')]
     public function testItWorks()
     {
         (new TestHelper())->expectMapperToConvertSourceTo(
             new MapEmployee(),
             '{
-                "teamMembers": [
-                    {
-                        "email": "p@example.com",
-                        "role": "Project manager"
-                    }
-                ]
+                "projectManagers": ["p@example.com"]
+
             }',
             Schema::project()->employee([
-                Schema::person()->email('p@example.com')->description('Project manager')
+                Schema::person()->email('p@example.com')
             ])
         );
     }
 
-    #[TestDox('project::employee is empty when teamMembers is empty')]
+    #[TestDox('project::employee is empty when projectManagers is empty')]
     public function testEmpty()
     {
         (new TestHelper())->expectMapperToConvertSourceTo(
             new MapEmployee(),
             '{
-                "teamMembers": []
+                "projectManagers": []
             }',
             Schema::project()->employee([])
         );
     }
 
-    #[TestDox('project::employee is empty when teamMembers is missing')]
+    #[TestDox('project::employee is empty when projectManagers is missing')]
     public function testMissing()
     {
         (new TestHelper())->expectMapperToConvertSourceTo(

--- a/src/Transforms/PiosProject/Mappers/Tests/MapFoundingDateTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapFoundingDateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapFoundingDate;
+
+#[CoversClass(MapFoundingDate::class)]
+final class MapFoundingDateTest extends TestCase
+{
+    #[TestDox('project::foundingDate is taken from startYear')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapFoundingDate(),
+            '{
+                "startYear": "2026"
+            }',
+            Schema::project()->foundingDate('2026')
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapFundingTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapFundingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapFunding;
+
+#[CoversClass(MapFunding::class)]
+final class MapFundingTest extends TestCase
+{
+    #[TestDox('project::funding is taken from funding')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapFunding(),
+            '{
+                "periods": [{
+                        "year": 2023,
+                        "_": "no budget, skipped"
+                    },
+                    {
+                        "year": 2024,
+                        "totalBudget": 1000000
+                    },
+                    {
+                        "year": 2025,
+                        "totalBudget": 2000000
+                    },
+                    {
+                        "totalBudget": 3000000
+                    }
+                ]
+            }',
+            Schema::project()->funding([
+                Schema::monetaryGrant()->amount(1000000)->name('2024'),
+                Schema::monetaryGrant()->amount(2000000)->name('2025'),
+                Schema::monetaryGrant()->amount(3000000)
+            ])
+        );
+    }
+
+    #[TestDox('project::funding is empty if periods is empty')]
+    public function testEmpty()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapFunding(),
+            '{
+                "periods": []
+            }',
+            Schema::project()->funding([])
+        );
+    }
+
+    #[TestDox('project::funding is empty if periods is missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapFunding(),
+            '{
+                "id": 123
+            }',
+            Schema::project()->funding([])
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapIdentifierTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapIdentifierTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\PiosProjectTransform;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapIdentifier;
+
+#[CoversClass(MapIdentifier::class)]
+final class MapIdentifierTest extends TestCase
+{
+    #[TestDox('project::identifier is taken from projectId')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapIdentifier(new PiosProjectTransform("pios-project-")),
+            '{
+                "projectId": "12345"
+            }',
+            Schema::project()->identifier('pios-project-12345')
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapKeywordsTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapKeywordsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapKeywords;
+
+#[CoversClass(MapKeywords::class)]
+final class MapKeywordsTest extends TestCase
+{
+    #[TestDox('project::keywords is taken from tags')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapKeywords(),
+            '{
+                "tags": [
+                    {"displayName": "Tag 1"},
+                    {"displayName": "Tag 2"},
+                    {"displayName": null},
+                    {},
+                    null
+                ]
+            }',
+            Schema::project()->keywords([
+                Schema::definedTerm()->name('Tag 1')->inDefinedTermSet(Schema::definedTermSet()->name('tags')),
+                Schema::definedTerm()->name('Tag 2')->inDefinedTermSet(Schema::definedTermSet()->name('tags'))
+            ])
+        );
+    }
+
+    #[TestDox('project::keywords is empty if tags are missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapKeywords(),
+            '{"id": 123}',
+            Schema::project()->keywords([])
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapNameTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapNameTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapName;
+
+#[CoversClass(MapName::class)]
+final class MapNameTest extends TestCase
+{
+    #[TestDox('project::name is take from title')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapName(),
+            '{
+                "title": "Test project"
+            }',
+            Schema::project()->name('Test project')
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapStatusTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapStatusTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapStatus;
+
+#[CoversClass(MapStatus::class)]
+final class MapStatusTest extends TestCase
+{
+    #[TestDox('project::status is taken from projectStatus and projectPhase')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapStatus(),
+            '{
+                "projectStatus": "One",
+                "projectPhase": "Started"
+            }',
+            Schema::project()->status(
+                Schema::progressStatus()
+                    ->minNumber(0)
+                    ->maxNumber(100)
+                    ->name('Pågående')
+                    ->number(33)
+            )
+        );
+    }
+
+    #[TestDox('project::status is defaulted if projectStatus and projectPhase are missing')]
+    public function testMissing()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapStatus(),
+            '{"id": 123}',
+            Schema::project()->status(
+                Schema::progressStatus()
+                    ->minNumber(0)
+                    ->maxNumber(100)
+                    ->name('Ingen status')
+                    ->number(0)
+            )
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/MapXCreatedByTest.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/MapXCreatedByTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Municipio\Schema\Schema;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapXCreatedBy;
+
+#[CoversClass(MapXCreatedBy::class)]
+final class MapXCreatedByTest extends TestCase
+{
+    #[TestDox('project::createdBy is hardcoded')]
+    public function testItWorks()
+    {
+        (new TestHelper())->expectMapperToConvertSourceTo(
+            new MapXCreatedBy(),
+            '{
+                "id": 123
+            }',
+            Schema::project()->setProperty('x-created-by', 'municipio://schema.org-transformer/pios-project')
+        );
+    }
+}

--- a/src/Transforms/PiosProject/Mappers/Tests/TestHelper.php
+++ b/src/Transforms/PiosProject/Mappers/Tests/TestHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject\Mappers\Tests;
+
+use PHPUnit\Framework\Assert;
+use Municipio\Schema\Schema;
+use Municipio\Schema\Project;
+use SchemaTransformer\Transforms\PiosProject\Mappers\PiosProjectMapperInterface;
+
+class TestHelper extends Assert
+{
+    protected function prepareJsonForTransform($json)
+    {
+        return json_decode($json, true);
+    }
+
+    public function expectMapperToConvertSourceTo(
+        PiosProjectMapperInterface $mapper,
+        string $sourceJson,
+        Project $expectedProject,
+        ?string $message = null
+    ): TestHelper {
+        $source = $this->prepareJsonForTransform($sourceJson);
+        $this->assertNotEmpty($source, 'Source data is empty or invalid JSON');
+
+        $actual = $mapper->map(Schema::project(), $source);
+
+        $this->assertEquals(
+            $expectedProject->toArray(),
+            $actual->toArray(),
+            $message ?: 'Mapper did not produce expected output for given source'
+        );
+
+        return $this;
+    }
+}

--- a/src/Transforms/PiosProject/PiosProjectTransform.php
+++ b/src/Transforms/PiosProject/PiosProjectTransform.php
@@ -4,8 +4,17 @@ declare(strict_types=1);
 
 namespace SchemaTransformer\Transforms\PiosProject;
 
+use Municipio\Schema\Schema;
 use SchemaTransformer\Interfaces\AbstractDataTransform;
 use SchemaTransformer\Transforms\TransformBase;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapDepartment;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapDescription;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapEmployee;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapFunding;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapIdentifier;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapName;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapStatus;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapXCreatedBy;
 
 class PiosProjectTransform extends TransformBase implements AbstractDataTransform
 {
@@ -14,8 +23,34 @@ class PiosProjectTransform extends TransformBase implements AbstractDataTransfor
         parent::__construct($idprefix);
     }
 
+    public function preprocessData(array $data): array
+    {
+        return $data['records'] ?? [];
+    }
+
     public function transform(array $data): array
     {
-        return $data;
+        $mappers = [
+            new MapIdentifier($this),
+            new MapName(),
+            new MapDescription(),
+            new MapFunding(),
+            new MapDepartment(),
+            new MapEmployee(),
+            new MapStatus(),
+
+            new MapXCreatedBy()
+        ];
+
+        $result = array_map(function ($item) use ($mappers) {
+            return array_reduce(
+                $mappers,
+                function ($project, $mapper) use ($item) {
+                    return $mapper->map($project, $item);
+                },
+                Schema::project()
+            )->toArray();
+        }, array_values($data));
+        return $result;
     }
 }

--- a/src/Transforms/PiosProject/PiosProjectTransform.php
+++ b/src/Transforms/PiosProject/PiosProjectTransform.php
@@ -12,6 +12,7 @@ use SchemaTransformer\Transforms\PiosProject\Mappers\MapDescription;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapEmployee;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapFunding;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapIdentifier;
+use SchemaTransformer\Transforms\PiosProject\Mappers\MapKeywords;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapName;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapStatus;
 use SchemaTransformer\Transforms\PiosProject\Mappers\MapXCreatedBy;
@@ -38,7 +39,7 @@ class PiosProjectTransform extends TransformBase implements AbstractDataTransfor
             new MapDepartment(),
             new MapEmployee(),
             new MapStatus(),
-
+            new MapKeywords(),
             new MapXCreatedBy()
         ];
 

--- a/src/Transforms/PiosProject/PiosProjectTransform.php
+++ b/src/Transforms/PiosProject/PiosProjectTransform.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchemaTransformer\Transforms\PiosProject;
+
+use SchemaTransformer\Interfaces\AbstractDataTransform;
+use SchemaTransformer\Transforms\TransformBase;
+
+class PiosProjectTransform extends TransformBase implements AbstractDataTransform
+{
+    public function __construct(string $idprefix)
+    {
+        parent::__construct($idprefix);
+    }
+
+    public function transform(array $data): array
+    {
+        return $data;
+    }
+}

--- a/src/Transforms/PiosProject/README.MD
+++ b/src/Transforms/PiosProject/README.MD
@@ -1,0 +1,2 @@
+## Swagger
+https://pios.dimatech.se/api/pios/swagger/index.html


### PR DESCRIPTION
This pull request introduces support for transforming PIOS Project data into the schema.org format within the project. It adds a new transformation pipeline, including mappers for various project fields, integration into the service layer, and CLI scripts for fetching, transforming, and uploading PIOS Project data. Unit tests are also added to ensure correct mapping behavior.

**PIOS Project Transformation Pipeline**

* Added a new transformation pipeline for PIOS Project data, including a set of dedicated mappers for fields such as identifier, name, description, department, employees, funding, keywords, founding date, status, and metadata (`x-created-by`). [[1]](diffhunk://#diff-0eeedf4ab1e503a05678a7db22de57b81739964a15ce82126f52768715c6db65R1-R22) [[2]](diffhunk://#diff-94e029a7c13e483b584f67a969d838e3186353a39d310a077acf19bebccddecaR1-R19) [[3]](diffhunk://#diff-d3911757a6fe25123b250f25051de3fb414fa2ed5f4476a2ff8f78dbb1609e84R1-R58) [[4]](diffhunk://#diff-16eb2adff99bb822586924a9fb3b4f45127c1cb121194083676b5d3eb1762fa2R1-R27) [[5]](diffhunk://#diff-96b6a9d78c68eee00c55d2d9718f4f7121643a8ed3f26a20c1668f81f157b71fR1-R15) [[6]](diffhunk://#diff-8837addc471dc86685bca5439d6df22c67de43be8b65288924c3df82269f6fceR1-R28) [[7]](diffhunk://#diff-4a2d4e264666f5df0193d1438b6f006809447b75983f8e77a11c72f2414af80eR1-R22) [[8]](diffhunk://#diff-781ca1d835540388513ddc8888744ef0d2b903a981d5b0ab0b58cb4672151460R1-R27) [[9]](diffhunk://#diff-c3cb72b1b9a2e9bd3008126cc319e1a9e8f5ad5a22898cc6ec51764be7c30e43R1-R15) [[10]](diffhunk://#diff-cb197856aee05cbc1f917e5003713dedbeb750e3af4c3ea434dcb18583d4baa3R1-R43) [[11]](diffhunk://#diff-000b629b551cab1db292dbb70c2160407f5b69c5259d34ceca07942bdb620230R1-R15) [[12]](diffhunk://#diff-46caad8b67077a7d251851575107a97b13435b88d243fbd5e0f116a36f349806R1-R12)

* Added unit tests for the new mappers to verify correct transformation of PIOS Project data. [[1]](diffhunk://#diff-ffb702f3e8d6a4cb8abea5a5082e75b643006ab6b7df0a8ee9de19accf68fe05R1-R29) [[2]](diffhunk://#diff-aec06afc0b85f0867843a390cf974e870b95933d6553d40fc9f9a116f6025203R1-R45)

**Service Layer Integration**

* Registered the new `PiosProjectTransform` in the `RuntimeServices` class and exposed it via a getter. [[1]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R23) [[2]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R36) [[3]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R83) [[4]](diffhunk://#diff-fe25d70cf5a5ddbb087048508d1a2e0cf988abd880a0d6c9461ff23f98057a83R124-R128)
* Updated the main application entrypoint to support the `pios_project` transform command.

**CLI Scripts for Data Operations**

* Added `run.sh` and `run-local.sh` scripts to fetch paginated PIOS Project data from the API, transform it, and (in the case of `run.sh`) upload the results to Typesense and clear its cache. These scripts handle API authentication, data transformation, and error handling. [[1]](diffhunk://#diff-76645e35223d00d7792ba9301861f48d8832eee2c701a60be89d86a6a7baa310R1-R96) [[2]](diffhunk://#diff-2499af970d011d60feb95301c52d7cf34ad4e87c8be6ab388067f9bed6ba2135R1-R57)